### PR TITLE
Collapse multiline logs based on a start line.

### DIFF
--- a/cmd/docker-driver/loki.go
+++ b/cmd/docker-driver/loki.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/pkg/logentry/stages"
+	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/promtail/api"
 	"github.com/grafana/loki/pkg/promtail/client"
 )
@@ -21,6 +22,8 @@ type loki struct {
 	handler api.EntryHandler
 	labels  model.LabelSet
 	logger  log.Logger
+
+	stop func()
 }
 
 // New create a new Loki logger that forward logs to Loki instance
@@ -35,18 +38,21 @@ func New(logCtx logger.Info, logger log.Logger) (logger.Logger, error) {
 		return nil, err
 	}
 	var handler api.EntryHandler = c
+	var stop func() = func() {}
 	if len(cfg.pipeline.PipelineStages) != 0 {
 		pipeline, err := stages.NewPipeline(logger, cfg.pipeline.PipelineStages, &jobName, prometheus.DefaultRegisterer)
 		if err != nil {
 			return nil, err
 		}
 		handler = pipeline.Wrap(c)
+		stop = handler.Stop
 	}
 	return &loki{
 		client:  c,
 		labels:  cfg.labels,
 		logger:  logger,
 		handler: handler,
+		stop:    stop,
 	}, nil
 }
 
@@ -60,7 +66,14 @@ func (l *loki) Log(m *logger.Message) error {
 	if m.Source != "" {
 		lbs["source"] = model.LabelValue(m.Source)
 	}
-	return l.handler.Handle(lbs, m.Timestamp, string(m.Line))
+	l.handler.Chan() <- api.Entry{
+		Labels: lbs,
+		Entry: logproto.Entry{
+			Timestamp: m.Timestamp,
+			Line:      string(m.Line),
+		},
+	}
+	return nil
 }
 
 // Log implements `logger.Logger`
@@ -70,6 +83,7 @@ func (l *loki) Name() string {
 
 // Log implements `logger.Logger`
 func (l *loki) Close() error {
+	l.stop()
 	l.client.StopNow()
 	return nil
 }

--- a/cmd/fluent-bit/dque.go
+++ b/cmd/fluent-bit/dque.go
@@ -11,6 +11,8 @@ import (
 	"github.com/joncrlsn/dque"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/api"
 	"github.com/grafana/loki/pkg/promtail/client"
 )
 
@@ -39,10 +41,12 @@ func dqueEntryBuilder() interface{} {
 }
 
 type dqueClient struct {
-	logger log.Logger
-	queue  *dque.DQue
-	loki   client.Client
-	once   sync.Once
+	logger  log.Logger
+	queue   *dque.DQue
+	loki    client.Client
+	once    sync.Once
+	wg      sync.WaitGroup
+	entries chan api.Entry
 }
 
 // New makes a new dque loki client
@@ -72,11 +76,16 @@ func newDque(cfg *config, logger log.Logger) (client.Client, error) {
 		return nil, err
 	}
 
+	q.entries = make(chan api.Entry)
+
+	q.wg.Add(2)
+	go q.enqueuer()
 	go q.dequeuer()
 	return q, nil
 }
 
 func (c *dqueClient) dequeuer() {
+	defer c.wg.Done()
 	for {
 		// Dequeue the next item in the queue
 		entry, err := c.queue.DequeueBlock()
@@ -97,29 +106,46 @@ func (c *dqueClient) dequeuer() {
 			continue
 		}
 
-		if err := c.loki.Handle(record.Lbs, record.Ts, record.Line); err != nil {
-			level.Error(c.logger).Log("msg", "error sending record to Loki", "error", err)
+		c.loki.Chan() <- api.Entry{
+			Labels: record.Lbs,
+			Entry: logproto.Entry{
+				Timestamp: record.Ts,
+				Line:      record.Line,
+			},
 		}
 	}
 }
 
 // Stop the client
 func (c *dqueClient) Stop() {
-	c.once.Do(func() { c.queue.Close() })
-	c.loki.Stop()
+	c.once.Do(func() {
+		close(c.entries)
+		c.queue.Close()
+		c.loki.Stop()
+		c.wg.Wait()
+	})
+
+}
+
+func (c *dqueClient) Chan() chan<- api.Entry {
+	return c.entries
 }
 
 // Stop the client
 func (c *dqueClient) StopNow() {
-	c.once.Do(func() { c.queue.Close() })
-	c.loki.StopNow()
+	c.once.Do(func() {
+		close(c.entries)
+		c.queue.Close()
+		c.loki.StopNow()
+		c.wg.Wait()
+	})
 }
 
-// Handle implement EntryHandler; adds a new line to the next batch; send is async.
-func (c *dqueClient) Handle(ls model.LabelSet, t time.Time, s string) error {
-	if err := c.queue.Enqueue(&dqueEntry{ls, t, s}); err != nil {
-		return fmt.Errorf("cannot enqueue record %s: %s", s, err)
+func (c *dqueClient) enqueuer() {
+	defer c.wg.Done()
+	for e := range c.entries {
+		if err := c.queue.Enqueue(&dqueEntry{e.Labels, e.Timestamp, e.Line}); err != nil {
+			level.Warn(c.logger).Log("msg", fmt.Sprintf("cannot enqueue record %s:", e.Line), "err", err)
+		}
 	}
-
-	return nil
 }

--- a/cmd/fluent-bit/loki.go
+++ b/cmd/fluent-bit/loki.go
@@ -16,6 +16,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/weaveworks/common/logging"
 
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/api"
 	"github.com/grafana/loki/pkg/promtail/client"
 )
 
@@ -63,15 +65,28 @@ func (l *loki) sendRecord(r map[interface{}]interface{}, ts time.Time) error {
 	}
 	if l.cfg.dropSingleKey && len(records) == 1 {
 		for _, v := range records {
-			return l.client.Handle(lbs, ts, fmt.Sprintf("%v", v))
+			l.client.Chan() <- api.Entry{
+				Labels: lbs,
+				Entry: logproto.Entry{
+					Timestamp: ts,
+					Line:      fmt.Sprintf("%v", v),
+				},
+			}
+			return nil
 		}
 	}
 	line, err := createLine(records, l.cfg.lineFormat)
 	if err != nil {
 		return fmt.Errorf("error creating line: %v", err)
 	}
-
-	return l.client.Handle(lbs, ts, line)
+	l.client.Chan() <- api.Entry{
+		Labels: lbs,
+		Entry: logproto.Entry{
+			Timestamp: ts,
+			Line:      line,
+		},
+	}
+	return nil
 }
 
 // prevent base64-encoding []byte values (default json.Encoder rule) by

--- a/cmd/fluent-bit/loki_test.go
+++ b/cmd/fluent-bit/loki_test.go
@@ -8,32 +8,11 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/api"
+	"github.com/grafana/loki/pkg/promtail/client/fake"
 )
-
-type entry struct {
-	lbs  model.LabelSet
-	line string
-	ts   time.Time
-}
-
-type recorder struct {
-	*entry
-}
-
-func (r *recorder) Handle(labels model.LabelSet, time time.Time, e string) error {
-	r.entry = &entry{
-		labels,
-		e,
-		time,
-	}
-	return nil
-}
-
-func (r *recorder) toEntry() *entry { return r.entry }
-
-func (r *recorder) Stop() {}
-
-func (r *recorder) StopNow() {}
 
 var now = time.Now()
 
@@ -78,24 +57,24 @@ func Test_loki_sendRecord(t *testing.T) {
 		name    string
 		cfg     *config
 		record  map[interface{}]interface{}
-		want    *entry
+		want    []api.Entry
 		wantErr bool
 	}{
-		{"map to JSON", &config{labelKeys: []string{"A"}, lineFormat: jsonFormat}, mapRecordFixture, &entry{model.LabelSet{"A": "A"}, `{"B":"B","C":"C","D":"D","E":"E","F":"F","G":"G","H":"H"}`, now}, false},
-		{"map to kvPairFormat", &config{labelKeys: []string{"A"}, lineFormat: kvPairFormat}, mapRecordFixture, &entry{model.LabelSet{"A": "A"}, `B=B C=C D=D E=E F=F G=G H=H`, now}, false},
-		{"not enough records", &config{labelKeys: []string{"foo"}, lineFormat: jsonFormat, removeKeys: []string{"bar", "error"}}, simpleRecordFixture, nil, false},
-		{"labels", &config{labelKeys: []string{"bar", "fake"}, lineFormat: jsonFormat, removeKeys: []string{"fuzz", "error"}}, simpleRecordFixture, &entry{model.LabelSet{"bar": "500"}, `{"foo":"bar"}`, now}, false},
-		{"remove key", &config{labelKeys: []string{"fake"}, lineFormat: jsonFormat, removeKeys: []string{"foo", "error", "fake"}}, simpleRecordFixture, &entry{model.LabelSet{}, `{"bar":500}`, now}, false},
-		{"error", &config{labelKeys: []string{"fake"}, lineFormat: jsonFormat, removeKeys: []string{"foo"}}, simpleRecordFixture, nil, true},
-		{"key value", &config{labelKeys: []string{"fake"}, lineFormat: kvPairFormat, removeKeys: []string{"foo", "error", "fake"}}, simpleRecordFixture, &entry{model.LabelSet{}, `bar=500`, now}, false},
-		{"single", &config{labelKeys: []string{"fake"}, dropSingleKey: true, lineFormat: kvPairFormat, removeKeys: []string{"foo", "error", "fake"}}, simpleRecordFixture, &entry{model.LabelSet{}, `500`, now}, false},
-		{"labelmap", &config{labelMap: map[string]interface{}{"bar": "other"}, lineFormat: jsonFormat, removeKeys: []string{"bar", "error"}}, simpleRecordFixture, &entry{model.LabelSet{"other": "500"}, `{"foo":"bar"}`, now}, false},
-		{"byte array", &config{labelKeys: []string{"label"}, lineFormat: jsonFormat}, byteArrayRecordFixture, &entry{model.LabelSet{"label": "label"}, `{"map":{"inner":"bar"},"outer":"foo"}`, now}, false},
-		{"mixed types", &config{labelKeys: []string{"label"}, lineFormat: jsonFormat}, mixedTypesRecordFixture, &entry{model.LabelSet{"label": "label"}, `{"array":[42,42.42,"foo"],"float":42.42,"int":42,"map":{"nested":{"foo":"bar","invalid":"a\ufffdz"}}}`, now}, false},
+		{"map to JSON", &config{labelKeys: []string{"A"}, lineFormat: jsonFormat}, mapRecordFixture, []api.Entry{{Labels: model.LabelSet{"A": "A"}, Entry: logproto.Entry{Line: `{"B":"B","C":"C","D":"D","E":"E","F":"F","G":"G","H":"H"}`, Timestamp: now}}}, false},
+		{"map to kvPairFormat", &config{labelKeys: []string{"A"}, lineFormat: kvPairFormat}, mapRecordFixture, []api.Entry{{Labels: model.LabelSet{"A": "A"}, Entry: logproto.Entry{Line: `B=B C=C D=D E=E F=F G=G H=H`, Timestamp: now}}}, false},
+		{"not enough records", &config{labelKeys: []string{"foo"}, lineFormat: jsonFormat, removeKeys: []string{"bar", "error"}}, simpleRecordFixture, []api.Entry{}, false},
+		{"labels", &config{labelKeys: []string{"bar", "fake"}, lineFormat: jsonFormat, removeKeys: []string{"fuzz", "error"}}, simpleRecordFixture, []api.Entry{{Labels: model.LabelSet{"bar": "500"}, Entry: logproto.Entry{Line: `{"foo":"bar"}`, Timestamp: now}}}, false},
+		{"remove key", &config{labelKeys: []string{"fake"}, lineFormat: jsonFormat, removeKeys: []string{"foo", "error", "fake"}}, simpleRecordFixture, []api.Entry{{Labels: model.LabelSet{}, Entry: logproto.Entry{Line: `{"bar":500}`, Timestamp: now}}}, false},
+		{"error", &config{labelKeys: []string{"fake"}, lineFormat: jsonFormat, removeKeys: []string{"foo"}}, simpleRecordFixture, []api.Entry{}, true},
+		{"key value", &config{labelKeys: []string{"fake"}, lineFormat: kvPairFormat, removeKeys: []string{"foo", "error", "fake"}}, simpleRecordFixture, []api.Entry{{Labels: model.LabelSet{}, Entry: logproto.Entry{Line: `bar=500`, Timestamp: now}}}, false},
+		{"single", &config{labelKeys: []string{"fake"}, dropSingleKey: true, lineFormat: kvPairFormat, removeKeys: []string{"foo", "error", "fake"}}, simpleRecordFixture, []api.Entry{{Labels: model.LabelSet{}, Entry: logproto.Entry{Line: `500`, Timestamp: now}}}, false},
+		{"labelmap", &config{labelMap: map[string]interface{}{"bar": "other"}, lineFormat: jsonFormat, removeKeys: []string{"bar", "error"}}, simpleRecordFixture, []api.Entry{{Labels: model.LabelSet{"other": "500"}, Entry: logproto.Entry{Line: `{"foo":"bar"}`, Timestamp: now}}}, false},
+		{"byte array", &config{labelKeys: []string{"label"}, lineFormat: jsonFormat}, byteArrayRecordFixture, []api.Entry{{Labels: model.LabelSet{"label": "label"}, Entry: logproto.Entry{Line: `{"map":{"inner":"bar"},"outer":"foo"}`, Timestamp: now}}}, false},
+		{"mixed types", &config{labelKeys: []string{"label"}, lineFormat: jsonFormat}, mixedTypesRecordFixture, []api.Entry{{Labels: model.LabelSet{"label": "label"}, Entry: logproto.Entry{Line: `{"array":[42,42.42,"foo"],"float":42.42,"int":42,"map":{"nested":{"foo":"bar","invalid":"a\ufffdz"}}}`, Timestamp: now}}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rec := &recorder{}
+			rec := fake.New(func() {})
 			l := &loki{
 				cfg:    tt.cfg,
 				client: rec,
@@ -106,7 +85,8 @@ func Test_loki_sendRecord(t *testing.T) {
 				t.Errorf("sendRecord() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			got := rec.toEntry()
+			rec.Stop()
+			got := rec.Received()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("sendRecord() want:%v got:%v", tt.want, got)
 			}

--- a/docs/sources/clients/promtail/pipelines.md
+++ b/docs/sources/clients/promtail/pipelines.md
@@ -206,6 +206,7 @@ Parsing stages:
 
 Transform stages:
 
+  - [multiline](../stages/multiline/): Merges multiple lines, e.g. stack traces, into multiline blocks.
   - [template](../stages/template/): Use Go templates to modify extracted data.
 
 Action stages:

--- a/docs/sources/clients/promtail/stages/multiline.md
+++ b/docs/sources/clients/promtail/stages/multiline.md
@@ -1,0 +1,21 @@
+---
+title: multiline 
+---
+
+# `multiline` stage
+
+...
+
+## Schema
+
+```yaml
+multiline:
+  # TODO: document
+  firstline: <string>
+
+  # TODO: document
+  max_lines: <integer>
+
+  # TODO: document
+  max_wait_time: <duration>
+```

--- a/docs/sources/getting-started/troubleshooting.md
+++ b/docs/sources/getting-started/troubleshooting.md
@@ -46,11 +46,11 @@ Promtail yet. There may be one of many root causes:
 Promtail exposes two web pages that can be used to understand how its service
 discovery works.
 
-The service discovery page (../service-discovery`) shows all
+The service discovery page (`/service-discovery`) shows all
 discovered targets with their labels before and after relabeling as well as
 the reason why the target has been dropped.
 
-The targets page (../targets`) displays only targets that are being actively
+The targets page (`/targets`) displays only targets that are being actively
 scraped and their respective labels, files, and positions.
 
 On Kubernetes, you can access those two pages by port-forwarding the Promtail
@@ -109,7 +109,7 @@ kubectl exec -it promtail-bth9q -- /bin/sh
 Once connected, verify the config in `/etc/promtail/promtail.yml` has the
 contents you expect.
 
-Also check `/var/log/positions.yaml` (../run/promtail/positions.yaml` when
+Also check `/var/log/positions.yaml` (`/run/promtail/positions.yaml` when
 deployed by Helm or whatever value is specified for `positions.file`) and make
 sure Promtail is tailing the logs you would expect.
 

--- a/pkg/chunkenc/README.md
+++ b/pkg/chunkenc/README.md
@@ -13,14 +13,14 @@
   --------------------------------------------------
   |         #blocks (uvarint)                      |
   --------------------------------------------------
-  | #entries(uvarint) | mint, maxt (varint) | offset, len (uvarint) |
-  -------------------------------------------------------------------
-  | #entries(uvarint) | mint, maxt (varint) | offset, len (uvarint) |
-  -------------------------------------------------------------------
-  | #entries(uvarint) | mint, maxt (varint) | offset, len (uvarint) |
-  -------------------------------------------------------------------
-  | #entries(uvarint) | mint, maxt (varint) | offset, len (uvarint) |
-  -------------------------------------------------------------------
+  | #entries(uvarint) | mint, maxt (varint) | offset, len (uvarint) | uncompressedSize (uvarint) |
+  ------------------------------------------------------------------------------------------------
+  | #entries(uvarint) | mint, maxt (varint) | offset, len (uvarint) | uncompressedSize (uvarint) |
+  ------------------------------------------------------------------------------------------------
+  | #entries(uvarint) | mint, maxt (varint) | offset, len (uvarint) | uncompressedSize (uvarint) |
+  ------------------------------------------------------------------------------------------------
+  | #entries(uvarint) | mint, maxt (varint) | offset, len (uvarint) | uncompressedSize (uvarint) |
+  ------------------------------------------------------------------------------------------------
   |                      checksum(from #blocks)                     |
   -------------------------------------------------------------------
   | metasOffset - offset to the point with #blocks |

--- a/pkg/logentry/stages/drop.go
+++ b/pkg/logentry/stages/drop.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-	"github.com/prometheus/common/model"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/loki/pkg/util/flagext"
 )
@@ -76,7 +76,7 @@ func validateDropConfig(cfg *DropConfig) error {
 }
 
 // newDropStage creates a DropStage from config
-func newDropStage(logger log.Logger, config interface{}) (Stage, error) {
+func newDropStage(logger log.Logger, config interface{}, registerer prometheus.Registerer) (Stage, error) {
 	cfg := &DropConfig{}
 	err := mapstructure.WeakDecode(config, cfg)
 	if err != nil {
@@ -88,55 +88,71 @@ func newDropStage(logger log.Logger, config interface{}) (Stage, error) {
 	}
 
 	return &dropStage{
-		logger: log.With(logger, "component", "stage", "type", "drop"),
-		cfg:    cfg,
+		logger:    log.With(logger, "component", "stage", "type", "drop"),
+		cfg:       cfg,
+		dropCount: getDropCountMetric(registerer),
 	}, nil
 }
 
 // dropStage applies Label matchers to determine if the include stages should be run
 type dropStage struct {
-	logger log.Logger
-	cfg    *DropConfig
+	logger    log.Logger
+	cfg       *DropConfig
+	dropCount *prometheus.CounterVec
 }
 
-// Process implements Stage
-func (m *dropStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+func (m *dropStage) Run(in chan Entry) chan Entry {
+	out := make(chan Entry)
+	go func() {
+		defer close(out)
+		for e := range in {
+			if !m.shouldDrop(e) {
+				out <- e
+				continue
+			}
+			m.dropCount.WithLabelValues(*m.cfg.DropReason)
+		}
+	}()
+	return out
+}
+
+func (m *dropStage) shouldDrop(e Entry) bool {
 	// There are many options for dropping a log and if multiple are defined it's treated like an AND condition
 	// where all drop conditions must be met to drop the log.
 	// Therefore if at any point there is a condition which does not match we can return.
 	// The order is what I roughly think would be fastest check to slowest check to try to quit early whenever possible
 
 	if m.cfg.LongerThan != nil {
-		if len([]byte(*entry)) > m.cfg.longerThan.Val() {
+		if len(e.Line) > m.cfg.longerThan.Val() {
 			// Too long, drop
 			if Debug {
-				level.Debug(m.logger).Log("msg", fmt.Sprintf("line met drop criteria for length %v > %v", len([]byte(*entry)), m.cfg.longerThan.Val()))
+				level.Debug(m.logger).Log("msg", fmt.Sprintf("line met drop criteria for length %v > %v", len(e.Line), m.cfg.longerThan.Val()))
 			}
 		} else {
 			if Debug {
-				level.Debug(m.logger).Log("msg", fmt.Sprintf("line will not be dropped, it did not meet criteria for drop length %v is not greater than %v", len([]byte(*entry)), m.cfg.longerThan.Val()))
+				level.Debug(m.logger).Log("msg", fmt.Sprintf("line will not be dropped, it did not meet criteria for drop length %v is not greater than %v", len(e.Line), m.cfg.longerThan.Val()))
 			}
-			return
+			return false
 		}
 	}
 
 	if m.cfg.OlderThan != nil {
 		ct := time.Now()
-		if t.Before(ct.Add(-m.cfg.olderThan)) {
+		if e.Timestamp.Before(ct.Add(-m.cfg.olderThan)) {
 			// Too old, drop
 			if Debug {
-				level.Debug(m.logger).Log("msg", fmt.Sprintf("line met drop criteria for age; current time=%v, drop before=%v, log timestamp=%v", ct, ct.Add(-m.cfg.olderThan), t))
+				level.Debug(m.logger).Log("msg", fmt.Sprintf("line met drop criteria for age; current time=%v, drop before=%v, log timestamp=%v", ct, ct.Add(-m.cfg.olderThan), e.Timestamp))
 			}
 		} else {
 			if Debug {
-				level.Debug(m.logger).Log("msg", fmt.Sprintf("line will not be dropped, it did not meet drop criteria for age; current time=%v, drop before=%v, log timestamp=%v", ct, ct.Add(-m.cfg.olderThan), t))
+				level.Debug(m.logger).Log("msg", fmt.Sprintf("line will not be dropped, it did not meet drop criteria for age; current time=%v, drop before=%v, log timestamp=%v", ct, ct.Add(-m.cfg.olderThan), e.Timestamp))
 			}
-			return
+			return false
 		}
 	}
 
 	if m.cfg.Source != nil && m.cfg.Expression == nil {
-		if v, ok := extracted[*m.cfg.Source]; ok {
+		if v, ok := e.Extracted[*m.cfg.Source]; ok {
 			if m.cfg.Value == nil {
 				// Found in map, no value set meaning drop if found in map
 				if Debug {
@@ -153,7 +169,7 @@ func (m *dropStage) Process(labels model.LabelSet, extracted map[string]interfac
 					if Debug {
 						level.Debug(m.logger).Log("msg", fmt.Sprintf("line will not be dropped, source key was found in extracted map but value '%v' did not match desired value '%v'", v, *m.cfg.Value))
 					}
-					return
+					return false
 				}
 			}
 		} else {
@@ -161,19 +177,19 @@ func (m *dropStage) Process(labels model.LabelSet, extracted map[string]interfac
 			if Debug {
 				level.Debug(m.logger).Log("msg", "line will not be dropped, the provided source was not found in the extracted map")
 			}
-			return
+			return false
 		}
 	}
 
 	if m.cfg.Expression != nil {
 		if m.cfg.Source != nil {
-			if v, ok := extracted[*m.cfg.Source]; ok {
+			if v, ok := e.Extracted[*m.cfg.Source]; ok {
 				s, err := getString(v)
 				if err != nil {
 					if Debug {
 						level.Debug(m.logger).Log("msg", "Failed to convert extracted map value to string, cannot test regex line will not be dropped.", "err", err, "type", reflect.TypeOf(v))
 					}
-					return
+					return false
 				}
 				match := m.cfg.regex.FindStringSubmatch(s)
 				if match == nil {
@@ -181,7 +197,7 @@ func (m *dropStage) Process(labels model.LabelSet, extracted map[string]interfac
 					if Debug {
 						level.Debug(m.logger).Log("msg", fmt.Sprintf("line will not be dropped, the provided regular expression did not match the value found in the extracted map for source key: %v", *m.cfg.Source))
 					}
-					return
+					return false
 				}
 				// regex match, will be dropped
 				if Debug {
@@ -193,28 +209,19 @@ func (m *dropStage) Process(labels model.LabelSet, extracted map[string]interfac
 				if Debug {
 					level.Debug(m.logger).Log("msg", "line will not be dropped, the provided source was not found in the extracted map")
 				}
-				return
+				return false
 			}
 		} else {
-			if entry != nil {
-				match := m.cfg.regex.FindStringSubmatch(*entry)
-				if match == nil {
-					// Not a match to the regex, don't drop
-					if Debug {
-						level.Debug(m.logger).Log("msg", "line will not be dropped, the provided regular expression did not match the log line")
-					}
-					return
-				}
+			match := m.cfg.regex.FindStringSubmatch(e.Line)
+			if match == nil {
+				// Not a match to the regex, don't drop
 				if Debug {
-					level.Debug(m.logger).Log("msg", "line met drop criteria, the provided regular expression matched the log line")
+					level.Debug(m.logger).Log("msg", "line will not be dropped, the provided regular expression did not match the log line")
 				}
-
-			} else {
-				// Not a match to entry was nil, do not drop
-				if Debug {
-					level.Debug(m.logger).Log("msg", "line will not be dropped, because it was nil and we can't regex match to nil")
-				}
-				return
+				return false
+			}
+			if Debug {
+				level.Debug(m.logger).Log("msg", "line met drop criteria, the provided regular expression matched the log line")
 			}
 		}
 	}
@@ -223,8 +230,7 @@ func (m *dropStage) Process(labels model.LabelSet, extracted map[string]interfac
 	if Debug {
 		level.Debug(m.logger).Log("msg", "all criteria met, line will be dropped")
 	}
-	// Adds the drop label to not be sent by the api.EntryHandler
-	labels[dropLabel] = model.LabelValue(*m.cfg.DropReason)
+	return true
 }
 
 // Name implements Stage

--- a/pkg/logentry/stages/extensions_test.go
+++ b/pkg/logentry/stages/extensions_test.go
@@ -69,13 +69,11 @@ func TestNewDocker(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create Docker parser: %s", err)
 			}
-			lbs := toLabelSet(tt.labels)
-			extr := map[string]interface{}{}
-			p.Process(lbs, extr, &tt.t, &tt.entry)
+			out := processEntries(p, newEntry(nil, toLabelSet(tt.labels), tt.entry, tt.t))[0]
 
-			assertLabels(t, tt.expectedLabels, lbs)
-			assert.Equal(t, tt.expectedEntry, tt.entry, "did not receive expected log entry")
-			if tt.t.Unix() != tt.expectedT.Unix() {
+			assertLabels(t, tt.expectedLabels, out.Labels)
+			assert.Equal(t, tt.expectedEntry, out.Line, "did not receive expected log entry")
+			if out.Timestamp.Unix() != tt.expectedT.Unix() {
 				t.Fatalf("mismatch ts want: %s got:%s", tt.expectedT, tt.t)
 			}
 		})
@@ -145,13 +143,11 @@ func TestNewCri(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create CRI parser: %s", err)
 			}
-			lbs := toLabelSet(tt.labels)
-			extr := map[string]interface{}{}
-			p.Process(lbs, extr, &tt.t, &tt.entry)
+			out := processEntries(p, newEntry(nil, toLabelSet(tt.labels), tt.entry, tt.t))[0]
 
-			assertLabels(t, tt.expectedLabels, lbs)
-			assert.Equal(t, tt.expectedEntry, tt.entry, "did not receive expected log entry")
-			if tt.t.Unix() != tt.expectedT.Unix() {
+			assertLabels(t, tt.expectedLabels, out.Labels)
+			assert.Equal(t, tt.expectedEntry, out.Line, "did not receive expected log entry")
+			if out.Timestamp.Unix() != tt.expectedT.Unix() {
 				t.Fatalf("mismatch ts want: %s got:%s", tt.expectedT, tt.t)
 			}
 		})

--- a/pkg/logentry/stages/json.go
+++ b/pkg/logentry/stages/json.go
@@ -66,7 +66,7 @@ type jsonStage struct {
 }
 
 // newJSONStage creates a new json pipeline stage from a config.
-func newJSONStage(logger log.Logger, config interface{}) (*jsonStage, error) {
+func newJSONStage(logger log.Logger, config interface{}) (Stage, error) {
 	cfg, err := parseJSONConfig(config)
 	if err != nil {
 		return nil, err
@@ -75,11 +75,11 @@ func newJSONStage(logger log.Logger, config interface{}) (*jsonStage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &jsonStage{
+	return toStage(&jsonStage{
 		cfg:         cfg,
 		expressions: expressions,
 		logger:      log.With(logger, "component", "stage", "type", "json"),
-	}, nil
+	}), nil
 }
 
 func parseJSONConfig(config interface{}) (*JSONConfig, error) {

--- a/pkg/logentry/stages/json_test.go
+++ b/pkg/logentry/stages/json_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 )
@@ -87,12 +86,8 @@ func TestPipeline_JSON(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			lbls := model.LabelSet{}
-			ts := time.Now()
-			entry := testData.entry
-			extracted := map[string]interface{}{}
-			pl.Process(lbls, extracted, &ts, &entry)
-			assert.Equal(t, testData.expectedExtract, extracted)
+			out := processEntries(pl, newEntry(nil, nil, testData.entry, time.Now()))[0]
+			assert.Equal(t, testData.expectedExtract, out.Extracted)
 		})
 	}
 }
@@ -364,12 +359,9 @@ func TestJSONParser_Parse(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create json parser: %s", err)
 			}
-			lbs := model.LabelSet{}
-			extr := tt.extracted
-			ts := time.Now()
-			p.Process(lbs, extr, &ts, &tt.entry)
+			out := processEntries(p, newEntry(tt.extracted, nil, tt.entry, time.Now()))[0]
 
-			assert.Equal(t, tt.expectedExtract, extr)
+			assert.Equal(t, tt.expectedExtract, out.Extracted)
 		})
 	}
 }

--- a/pkg/logentry/stages/labeldrop.go
+++ b/pkg/logentry/stages/labeldrop.go
@@ -24,7 +24,7 @@ func validateLabelDropConfig(c LabelDropConfig) error {
 	return nil
 }
 
-func newLabelDropStage(configs interface{}) (*labelDropStage, error) {
+func newLabelDropStage(configs interface{}) (Stage, error) {
 	cfgs := &LabelDropConfig{}
 	err := mapstructure.Decode(configs, cfgs)
 	if err != nil {
@@ -36,9 +36,9 @@ func newLabelDropStage(configs interface{}) (*labelDropStage, error) {
 		return nil, err
 	}
 
-	return &labelDropStage{
+	return toStage(&labelDropStage{
 		cfgs: *cfgs,
-	}, nil
+	}), nil
 }
 
 type labelDropStage struct {

--- a/pkg/logentry/stages/labeldrop_test.go
+++ b/pkg/logentry/stages/labeldrop_test.go
@@ -2,6 +2,7 @@ package stages
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/prometheus/common/model"
@@ -63,8 +64,8 @@ func Test_dropLabelStage_Process(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			st.Process(test.inputLabels, map[string]interface{}{}, nil, nil)
-			assert.Equal(t, test.expectedLabels, test.inputLabels)
+			out := processEntries(st, newEntry(nil, test.inputLabels, "", time.Now()))[0]
+			assert.Equal(t, test.expectedLabels, out.Labels)
 		})
 	}
 }

--- a/pkg/logentry/stages/labels.go
+++ b/pkg/logentry/stages/labels.go
@@ -39,7 +39,7 @@ func validateLabelsConfig(c LabelsConfig) error {
 }
 
 // newLabelStage creates a new label stage to set labels from extracted data
-func newLabelStage(logger log.Logger, configs interface{}) (*labelStage, error) {
+func newLabelStage(logger log.Logger, configs interface{}) (Stage, error) {
 	cfgs := &LabelsConfig{}
 	err := mapstructure.Decode(configs, cfgs)
 	if err != nil {
@@ -49,10 +49,10 @@ func newLabelStage(logger log.Logger, configs interface{}) (*labelStage, error) 
 	if err != nil {
 		return nil, err
 	}
-	return &labelStage{
+	return toStage(&labelStage{
 		cfgs:   *cfgs,
 		logger: logger,
-	}, nil
+	}), nil
 }
 
 // labelStage sets labels from extracted data

--- a/pkg/logentry/stages/labels_test.go
+++ b/pkg/logentry/stages/labels_test.go
@@ -47,16 +47,13 @@ func TestLabelsPipeline_Labels(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lbls := model.LabelSet{}
 	expectedLbls := model.LabelSet{
 		"level": "WARN",
 		"app":   "loki",
 	}
-	ts := time.Now()
-	entry := testLabelsLogLine
-	extracted := map[string]interface{}{}
-	pl.Process(lbls, extracted, &ts, &entry)
-	assert.Equal(t, expectedLbls, lbls)
+
+	out := processEntries(pl, newEntry(nil, nil, testLabelsLogLine, time.Now()))[0]
+	assert.Equal(t, expectedLbls, out.Labels)
 }
 
 func TestLabelsPipelineWithMissingKey_Labels(t *testing.T) {
@@ -67,12 +64,10 @@ func TestLabelsPipelineWithMissingKey_Labels(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lbls := model.LabelSet{}
 	Debug = true
-	ts := time.Now()
-	entry := testLabelsLogLineWithMissingKey
-	extracted := map[string]interface{}{}
-	pl.Process(lbls, extracted, &ts, &entry)
+
+	_ = processEntries(pl, newEntry(nil, nil, testLabelsLogLineWithMissingKey, time.Now()))
+
 	expectedLog := "level=debug msg=\"failed to convert extracted label value to string\" err=\"Can't convert <nil> to string\" type=null"
 	if !(strings.Contains(buf.String(), expectedLog)) {
 		t.Errorf("\nexpected: %s\n+actual: %s", expectedLog, buf.String())
@@ -187,8 +182,9 @@ func TestLabelStage_Process(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			st.Process(test.inputLabels, test.extractedData, nil, nil)
-			assert.Equal(t, test.expectedLabels, test.inputLabels)
+
+			out := processEntries(st, newEntry(test.extractedData, test.inputLabels, "", time.Time{}))[0]
+			assert.Equal(t, test.expectedLabels, out.Labels)
 		})
 	}
 }

--- a/pkg/logentry/stages/match.go
+++ b/pkg/logentry/stages/match.go
@@ -1,8 +1,6 @@
 package stages
 
 import (
-	"time"
-
 	"github.com/prometheus/prometheus/pkg/labels"
 
 	"github.com/go-kit/kit/log"
@@ -11,7 +9,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/promtail/api"
 	"github.com/grafana/loki/pkg/util"
 )
 
@@ -108,6 +108,7 @@ func newMatcherStage(logger log.Logger, jobName *string, config interface{}, reg
 
 	return &matcherStage{
 		dropReason: dropReason,
+		dropCount:  getDropCountMetric(registerer),
 		matchers:   selector.Matchers(),
 		stage:      pl,
 		action:     cfg.Action,
@@ -115,40 +116,110 @@ func newMatcherStage(logger log.Logger, jobName *string, config interface{}, reg
 	}, nil
 }
 
+func getDropCountMetric(registerer prometheus.Registerer) *prometheus.CounterVec {
+	dropCount := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "logentry",
+		Name:      "dropped_lines_total",
+		Help:      "A count of all log lines dropped as a result of a pipeline stage",
+	}, []string{"reason"})
+	err := registerer.Register(dropCount)
+	if err != nil {
+		if existing, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			dropCount = existing.ExistingCollector.(*prometheus.CounterVec)
+		} else {
+			// Same behavior as MustRegister if the error is not for AlreadyRegistered
+			panic(err)
+		}
+	}
+	return dropCount
+}
+
 // matcherStage applies Label matchers to determine if the include stages should be run
 type matcherStage struct {
 	dropReason string
+	dropCount  *prometheus.CounterVec
 	matchers   []*labels.Matcher
 	pipeline   logql.Pipeline
 	stage      Stage
 	action     string
 }
 
-// Process implements Stage
-func (m *matcherStage) Process(lbs model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
-	for _, filter := range m.matchers {
-		if !filter.Matches(string(lbs[model.LabelName(filter.Name)])) {
-			return
-		}
+func (m *matcherStage) Run(in chan Entry) chan Entry {
+	switch m.action {
+	case MatchActionDrop:
+		return m.runDrop(in)
+	case MatchActionKeep:
+		return m.runKeep(in)
 	}
+	panic("unexpected action")
+}
 
-	sp := m.pipeline.ForStream(labels.FromMap(util.ModelLabelSetToMap(lbs)))
-	if newLine, newLabels, ok := sp.ProcessString(*entry); ok {
-		switch m.action {
-		case MatchActionDrop:
-			// Adds the drop label to not be sent by the api.EntryHandler
-			lbs[dropLabel] = model.LabelValue(m.dropReason)
-		case MatchActionKeep:
-			*entry = newLine
-			for k := range lbs {
-				delete(lbs, k)
+func (m *matcherStage) runKeep(in chan Entry) chan Entry {
+	next := make(chan Entry)
+	out := make(chan Entry)
+	outNext := m.stage.Run(next)
+	go func() {
+		defer close(out)
+		for e := range outNext {
+			out <- e
+		}
+	}()
+	go func() {
+		defer close(next)
+		for e := range in {
+			e, ok := m.processLogQL(e)
+			if !ok {
+				out <- e
+				continue
 			}
-			for _, l := range newLabels.Labels() {
-				lbs[model.LabelName(l.Name)] = model.LabelValue(l.Value)
+			next <- e
+		}
+	}()
+	return out
+}
+
+func (m *matcherStage) runDrop(in chan Entry) chan Entry {
+	out := make(chan Entry)
+	go func() {
+		defer close(out)
+		for e := range in {
+			if e, ok := m.processLogQL(e); !ok {
+				out <- e
+				continue
 			}
-			m.stage.Process(lbs, extracted, t, entry)
+			m.dropCount.WithLabelValues(m.dropReason).Inc()
+		}
+	}()
+	return out
+}
+
+func (m *matcherStage) processLogQL(e Entry) (Entry, bool) {
+	for _, filter := range m.matchers {
+		if !filter.Matches(string(e.Labels[model.LabelName(filter.Name)])) {
+			return e, false
 		}
 	}
+	sp := m.pipeline.ForStream(labels.FromMap(util.ModelLabelSetToMap(e.Labels)))
+	newLine, newLabels, ok := sp.ProcessString(e.Line)
+	if !ok {
+		return e, false
+	}
+	for k := range e.Labels {
+		delete(e.Labels, k)
+	}
+	for _, l := range newLabels.Labels() {
+		e.Labels[model.LabelName(l.Name)] = model.LabelValue(l.Value)
+	}
+	return Entry{
+		Extracted: e.Extracted,
+		Entry: api.Entry{
+			Labels: e.Labels,
+			Entry: logproto.Entry{
+				Line:      newLine,
+				Timestamp: e.Timestamp,
+			},
+		},
+	}, true
 }
 
 // Name implements Stage

--- a/pkg/logentry/stages/metrics.go
+++ b/pkg/logentry/stages/metrics.go
@@ -85,7 +85,7 @@ func validateMetricsConfig(cfg MetricsConfig) error {
 }
 
 // newMetricStage creates a new set of metrics to process for each log entry
-func newMetricStage(logger log.Logger, config interface{}, registry prometheus.Registerer) (*metricStage, error) {
+func newMetricStage(logger log.Logger, config interface{}, registry prometheus.Registerer) (Stage, error) {
 	cfgs := &MetricsConfig{}
 	err := mapstructure.Decode(config, cfgs)
 	if err != nil {
@@ -128,11 +128,11 @@ func newMetricStage(logger log.Logger, config interface{}, registry prometheus.R
 			metrics[name] = collector
 		}
 	}
-	return &metricStage{
+	return toStage(&metricStage{
 		logger:  logger,
 		cfg:     *cfgs,
 		metrics: metrics,
-	}, nil
+	}), nil
 }
 
 // metricStage creates and updates prometheus metrics based on extracted pipeline data
@@ -144,9 +144,6 @@ type metricStage struct {
 
 // Process implements Stage
 func (m *metricStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
-	if _, ok := labels[dropLabel]; ok {
-		return
-	}
 	for name, collector := range m.metrics {
 		// There is a special case for counters where we count even if there is no match in the extracted map.
 		if c, ok := collector.(*metric.Counters); ok {

--- a/pkg/logentry/stages/metrics_test.go
+++ b/pkg/logentry/stages/metrics_test.go
@@ -114,14 +114,10 @@ func TestMetricsPipeline(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lbls := model.LabelSet{}
-	lbls["test"] = "app"
-	ts := time.Now()
-	extracted := map[string]interface{}{}
-	entry := testMetricLogLine1
-	pl.Process(lbls, extracted, &ts, &entry)
-	entry = testMetricLogLine2
-	pl.Process(lbls, extracted, &ts, &entry)
+
+	out := <-pl.Run(withInboundEntries(newEntry(nil, model.LabelSet{"test": "app"}, testMetricLogLine1, time.Now())))
+	out.Line = testMetricLogLine2
+	<-pl.Run(withInboundEntries(out))
 
 	if err := testutil.GatherAndCompare(registry,
 		strings.NewReader(expectedMetrics)); err != nil {
@@ -137,12 +133,8 @@ func TestPipelineWithMissingKey_Metrics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lbls := model.LabelSet{}
 	Debug = true
-	ts := time.Now()
-	entry := testMetricLogLineWithMissingKey
-	extracted := map[string]interface{}{}
-	pl.Process(lbls, extracted, &ts, &entry)
+	processEntries(pl, newEntry(nil, nil, testMetricLogLineWithMissingKey, time.Now()))
 	expectedLog := "level=debug msg=\"failed to convert extracted value to string, can't perform value comparison\" metric=bloki_count err=\"can't convert <nil> to string\""
 	if !(strings.Contains(buf.String(), expectedLog)) {
 		t.Errorf("\nexpected: %s\n+actual: %s", expectedLog, buf.String())
@@ -167,9 +159,12 @@ pipeline_stages:
         action: inc
 `
 
-const expectedDropMetrics = `# HELP promtail_custom_loki_count should only inc on non dropped labels
+const expectedDropMetrics = `# HELP logentry_dropped_lines_total A count of all log lines dropped as a result of a pipeline stage
+# TYPE logentry_dropped_lines_total counter
+logentry_dropped_lines_total{reason="match_stage"} 1
+# HELP promtail_custom_loki_count should only inc on non dropped labels
 # TYPE promtail_custom_loki_count counter
-promtail_custom_loki_count 1.0
+promtail_custom_loki_count 1
 `
 
 func TestMetricsWithDropInPipeline(t *testing.T) {
@@ -182,13 +177,16 @@ func TestMetricsWithDropInPipeline(t *testing.T) {
 	droppingLabels := model.LabelSet{
 		"drop": "true",
 	}
+	in := make(chan Entry)
+	out := pl.Run(in)
 
-	ts := time.Now()
-	extracted := map[string]interface{}{}
-	entry := testMetricLogLine1
-	pl.Process(lbls, extracted, &ts, &entry)
-	entry = testMetricLogLine2
-	pl.Process(droppingLabels, extracted, &ts, &entry)
+	in <- newEntry(nil, lbls, testMetricLogLine1, time.Now())
+	e := <-out
+	e.Labels = droppingLabels
+	e.Line = testMetricLogLine2
+	in <- e
+	close(in)
+	<-out
 
 	if err := testutil.GatherAndCompare(registry,
 		strings.NewReader(expectedDropMetrics)); err != nil {
@@ -198,7 +196,7 @@ func TestMetricsWithDropInPipeline(t *testing.T) {
 
 var metricTestInvalidIdle = "10f"
 
-func Test(t *testing.T) {
+func TestValidateMetricsConfig(t *testing.T) {
 	tests := map[string]struct {
 		config MetricsConfig
 		err    error
@@ -266,7 +264,7 @@ func TestDefaultIdleDuration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create stage with metrics: %v", err)
 	}
-	assert.Equal(t, int64(5*time.Minute.Seconds()), ms.(*metricStage).cfg["total_keys"].maxIdleSec)
+	assert.Equal(t, int64(5*time.Minute.Seconds()), ms.(*stageProcessor).Processor.(*metricStage).cfg["total_keys"].maxIdleSec)
 }
 
 var labelFoo = model.LabelSet(map[model.LabelName]model.LabelValue{"foo": "bar", "bar": "foo"})
@@ -372,15 +370,13 @@ func TestMetricStage_Process(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create stage with metrics: %v", err)
 	}
-	var ts = time.Now()
-	var entry = logFixture
-	extr := map[string]interface{}{}
-	jsonStage.Process(labelFoo, extr, &ts, &entry)
-	regexStage.Process(labelFoo, extr, &ts, &regexLogFixture)
-	metricStage.Process(labelFoo, extr, &ts, &entry)
+	out := processEntries(jsonStage, newEntry(nil, labelFoo, logFixture, time.Now()))
+	out[0].Line = regexLogFixture
+	out = processEntries(regexStage, out...)
+	out = processEntries(metricStage, out...)
+	out[0].Labels = labelFu
 	// Process the same extracted values again with different labels so we can verify proper metric/label assignments
-	metricStage.Process(labelFu, extr, &ts, &entry)
-
+	_ = processEntries(metricStage, out...)
 	names := metricNames(metricsConfig)
 	if err := testutil.GatherAndCompare(registry,
 		strings.NewReader(goldenMetrics), names...); err != nil {

--- a/pkg/logentry/stages/multiline.go
+++ b/pkg/logentry/stages/multiline.go
@@ -15,15 +15,15 @@ import (
 )
 
 const (
-	ErrMultilineStageEmptyConfig  = "multiline stage config must define `firstline` regular expression"
-	ErrMultilineStageInvalidRegex = "multiline stage first line regex compilation error: %v"
+	ErrMultilineStageEmptyConfig        = "multiline stage config must define `firstline` regular expression"
+	ErrMultilineStageInvalidRegex       = "multiline stage first line regex compilation error: %v"
 	ErrMultilineStageInvalidMaxWaitTime = "multiline stage `max_wait_time` parse error: %v"
 )
 
 // MultilineConfig contains the configuration for a multilineStage
 type MultilineConfig struct {
 	Expression  *string `mapstructure:"firstline"`
-	MaxWaitTime *string  `mapstructure:"max_wait_time"`
+	MaxWaitTime *string `mapstructure:"max_wait_time"`
 	maxWait     time.Duration
 	regex       *regexp.Regexp
 }
@@ -50,9 +50,9 @@ func validateMultilineConfig(cfg *MultilineConfig) error {
 
 // dropMultiline matches lines to determine whether the following lines belong to a block and should be collapsed
 type multilineStage struct {
-	logger log.Logger
-	cfg    *MultilineConfig
-	buffer *bytes.Buffer
+	logger         log.Logger
+	cfg            *MultilineConfig
+	buffer         *bytes.Buffer
 	startLineEntry Entry
 }
 
@@ -81,14 +81,14 @@ func (m *multilineStage) Run(in chan Entry) chan Entry {
 		defer close(out)
 		for {
 			select {
-			case <- time.After(m.cfg.maxWait):
+			case <-time.After(m.cfg.maxWait):
 				level.Debug(m.logger).Log("msg", fmt.Sprintf("flush multiline block due to %v timeout", m.cfg.maxWait), "block", m.buffer.String())
 				m.flush(out)
-			case e, ok := <- in:
+			case e, ok := <-in:
 				if !ok {
 					level.Debug(m.logger).Log("msg", "flush multiline block because inbound closed", "block", m.buffer.String())
 					m.flush(out)
-					return	
+					return
 				}
 
 				isFirstLine := m.cfg.regex.MatchString(e.Line)
@@ -121,7 +121,7 @@ func (m *multilineStage) flush(out chan Entry) {
 			Labels: m.startLineEntry.Entry.Labels,
 			Entry: logproto.Entry{
 				Timestamp: m.startLineEntry.Entry.Entry.Timestamp,
-				Line: m.buffer.String(),
+				Line:      m.buffer.String(),
 			},
 		},
 	}

--- a/pkg/logentry/stages/multiline.go
+++ b/pkg/logentry/stages/multiline.go
@@ -1,0 +1,125 @@
+package stages
+
+import (
+	"bytes"
+	"regexp"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+)
+
+const (
+	ErrMultilineStageEmptyConfig  = "multiline stage config must define `firstline` regular expression"
+	ErrMultilineStageInvalidRegex = "multiline stage first line regex compilation error: %v"
+	ErrMultilineStageInvalidMaxWaitTime = "multiline stage `max_wait_time` parse error: %v"
+)
+
+// MultilineConfig contains the configuration for a multilineStage
+type MultilineConfig struct {
+	Expression  *string `mapstructure:"firstline"`
+	MaxWaitTime *string  `mapstructure:"max_wait_time"`
+	maxWait     time.Duration
+	regex       *regexp.Regexp
+}
+
+func validateMultilineConfig(cfg *MultilineConfig) error {
+	if cfg == nil ||
+		(cfg.Expression == nil) {
+		return errors.New(ErrMultilineStageEmptyConfig)
+	}
+
+	expr, err := regexp.Compile(*cfg.Expression)
+	if err != nil {
+		return errors.Errorf(ErrMultilineStageInvalidRegex, err)
+	}
+	cfg.regex = expr
+
+	maxWait, err := time.ParseDuration(*cfg.MaxWaitTime)
+	if err != nil {
+		return errors.Errorf(ErrMultilineStageInvalidMaxWaitTime, err)
+	}
+	cfg.maxWait = maxWait
+
+	return nil
+}
+
+// dropMultiline matches lines to determine whether the following lines belong to a block and should be collapsed
+type multilineStage struct {
+	logger log.Logger
+	cfg    *MultilineConfig
+	buffer *bytes.Buffer
+	startLineEntry Entry
+}
+
+// newMulitlineStage creates a MulitlineStage from config
+func newMultilineStage(logger log.Logger, config interface{}) (Stage, error) {
+	cfg := &MultilineConfig{}
+	err := mapstructure.WeakDecode(config, cfg)
+	if err != nil {
+		return nil, err
+	}
+	err = validateMultilineConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &multilineStage{
+		logger: log.With(logger, "component", "stage", "type", "multiline"),
+		cfg:    cfg,
+		buffer: new(bytes.Buffer),
+	}, nil
+}
+
+func (m *multilineStage) Run(in chan Entry) chan Entry {
+	out := make(chan Entry)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <- time.After(m.cfg.maxWait):
+				m.flush(out)
+			case e, ok := <- in:
+				if !ok {
+					return	
+				}
+
+				isFirstLine := m.cfg.regex.MatchString(e.Line)
+				if isFirstLine {
+					m.flush(out)
+					// TODO: we only consider the labels and timestamp from the firt entry. Should merge all entries?
+					m.startLineEntry = e
+				}
+
+				// Append block line
+				if m.buffer.Len() > 0 {
+					m.buffer.WriteRune('\n')
+				}
+				m.buffer.WriteString(e.Line)
+			}
+		}
+	}()
+	return out
+}
+
+func (m *multilineStage) flush(out chan Entry) {
+	if m.buffer.Len() == 0 {
+		return
+	}
+
+	collapsed := &Entry{
+		Labels: m.startLineEntry.Labels,
+		Extracted: m.startLineEntry.Extracted,
+		Timestamp: m.startLineEntry.Timestamp,
+		Line: m.buffer.String(),
+	}
+	m.buffer.Reset()
+
+	out <- *collapsed
+}
+
+// Name implements Stage
+func (m *multilineStage) Name() string {
+	return StageTypeMultiline
+}

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -1,0 +1,47 @@
+package stages
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	ww "github.com/weaveworks/common/server"
+)
+
+func Test_multilineStage_Process(t *testing.T) {
+
+	// Enable debug logging
+	cfg := &ww.Config{}
+	require.Nil(t, cfg.LogLevel.Set("debug"))
+	util.InitLogger(cfg)
+	Debug = true
+
+	mcfg := &MultilineConfig{Expression: ptrFromString("^START")}
+	err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{
+		cfg:    mcfg,
+		logger: util.Logger,
+		buffer: new(bytes.Buffer),
+	}
+
+	out := processEntries(stage, simpleEntry("START line 1"), simpleEntry("not a start line"), simpleEntry("START line 2"), simpleEntry("START line 3"))
+
+	require.Equal(t, "START line 1\nnot a start line", out[0].Line)
+	require.Equal(t, "START line 2", out[1].Line)
+	require.Equal(t, "START line 3", out[2].Line)
+}
+
+func simpleEntry(line string) Entry {
+	return Entry{
+				Labels:    model.LabelSet{},
+				Line:      ptrFromString(line),
+				Extracted: map[string]interface{}{},
+				Timestamp: ptrFromTime(time.Now()),
+			}
+
+}

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -1,7 +1,6 @@
 package stages
 
 import (
-	"bytes"
 	"sync"
 	"testing"
 	"time"
@@ -29,7 +28,6 @@ func Test_multilineStage_Process(t *testing.T) {
 	stage := &multilineStage{
 		cfg:    mcfg,
 		logger: util.Logger,
-		buffer: new(bytes.Buffer),
 	}
 
 	out := processEntries(stage, simpleEntry("START line 1"), simpleEntry("not a start line"), simpleEntry("START line 2"), simpleEntry("START line 3"))
@@ -54,7 +52,6 @@ func Test_multilineStage_MaxWaitTime(t *testing.T) {
 	stage := &multilineStage{
 		cfg:    mcfg,
 		logger: util.Logger,
-		buffer: new(bytes.Buffer),
 	}
 
 	in := make(chan Entry, 2)

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -87,21 +87,21 @@ func Test_multilineStage_MaxWaitTime(t *testing.T) {
 		return
 	}()
 
-	require.Eventually(t, func() bool {mu.Lock(); defer mu.Unlock(); return len(res) == 2;}, time.Duration(3 * maxWait), time.Second)
+	require.Eventually(t, func() bool { mu.Lock(); defer mu.Unlock(); return len(res) == 2 }, time.Duration(3*maxWait), time.Second)
 	require.Equal(t, "START line", res[0].Line)
 	require.Equal(t, "not a start line hitting timeout", res[1].Line)
 }
 
 func simpleEntry(line string) Entry {
 	return Entry{
-				Extracted: map[string]interface{}{},
-				Entry: api.Entry{
-					Labels:    model.LabelSet{},
-					Entry: logproto.Entry{
-						Timestamp: time.Now(),
-						Line: line,
-					},
-				},
-			}
+		Extracted: map[string]interface{}{},
+		Entry: api.Entry{
+			Labels: model.LabelSet{},
+			Entry: logproto.Entry{
+				Timestamp: time.Now(),
+				Line:      line,
+			},
+		},
+	}
 
 }

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -1,6 +1,7 @@
 package stages
 
 import (
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -30,13 +31,62 @@ func Test_multilineStage_Process(t *testing.T) {
 		logger: util.Logger,
 	}
 
-	out := processEntries(stage, simpleEntry("START line 1"), simpleEntry("not a start line"), simpleEntry("START line 2"), simpleEntry("START line 3"))
+	out := processEntries(stage,
+		simpleEntry("START line 1", "label"),
+		simpleEntry("not a start line", "label"),
+		simpleEntry("START line 2", "label"),
+		simpleEntry("START line 3", "label"))
 
 	require.Len(t, out, 3)
 	require.Equal(t, "START line 1\nnot a start line", out[0].Line)
 	require.Equal(t, "START line 2", out[1].Line)
 	require.Equal(t, "START line 3", out[2].Line)
 }
+func Test_multilineStage_MultiStreams(t *testing.T) {
+	// Enable debug logging
+	cfg := &ww.Config{}
+	require.Nil(t, cfg.LogLevel.Set("debug"))
+	util.InitLogger(cfg)
+	Debug = true
+
+	mcfg := &MultilineConfig{Expression: ptrFromString("^START"), MaxWaitTime: ptrFromString("3s")}
+	err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{
+		cfg:    mcfg,
+		logger: util.Logger,
+	}
+
+	out := processEntries(stage,
+		simpleEntry("START line 1", "one"),
+		simpleEntry("not a start line 1", "one"),
+		simpleEntry("START line 1", "two"),
+		simpleEntry("not a start line 2", "one"),
+		simpleEntry("START line 2", "two"),
+		simpleEntry("START line 2", "one"),
+		simpleEntry("not a start line 1", "one"),
+	)
+
+	sort.Slice(out, func(l, r int) bool {
+		return out[l].Timestamp.Before(out[r].Timestamp)
+	})
+
+	require.Len(t, out, 4)
+
+	require.Equal(t, "START line 1\nnot a start line 1\nnot a start line 2", out[0].Line)
+	require.Equal(t, model.LabelValue("one"), out[0].Labels["value"])
+
+	require.Equal(t, "START line 1", out[1].Line)
+	require.Equal(t, model.LabelValue("two"), out[1].Labels["value"])
+
+	require.Equal(t, "START line 2", out[2].Line)
+	require.Equal(t, model.LabelValue("two"), out[2].Labels["value"])
+
+	require.Equal(t, "START line 2\nnot a start line 1", out[3].Line)
+	require.Equal(t, model.LabelValue("one"), out[3].Labels["value"])
+}
+
 func Test_multilineStage_MaxWaitTime(t *testing.T) {
 	// Enable debug logging
 	cfg := &ww.Config{}
@@ -72,12 +122,12 @@ func Test_multilineStage_MaxWaitTime(t *testing.T) {
 
 	// Write input with a delay
 	go func() {
-		in <- simpleEntry("START line")
+		in <- simpleEntry("START line", "label")
 
 		// Trigger flush due to max wait timeout
 		time.Sleep(2 * maxWait)
 
-		in <- simpleEntry("not a start line hitting timeout")
+		in <- simpleEntry("not a start line hitting timeout", "label")
 
 		// Signal pipeline we are done.
 		close(in)
@@ -89,11 +139,11 @@ func Test_multilineStage_MaxWaitTime(t *testing.T) {
 	require.Equal(t, "not a start line hitting timeout", res[1].Line)
 }
 
-func simpleEntry(line string) Entry {
+func simpleEntry(line, label string) Entry {
 	return Entry{
 		Extracted: map[string]interface{}{},
 		Entry: api.Entry{
-			Labels: model.LabelSet{},
+			Labels: model.LabelSet{"value": model.LabelValue(label)},
 			Entry: logproto.Entry{
 				Timestamp: time.Now(),
 				Line:      line,

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -2,10 +2,13 @@ package stages
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/api"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	ww "github.com/weaveworks/common/server"
@@ -19,7 +22,7 @@ func Test_multilineStage_Process(t *testing.T) {
 	util.InitLogger(cfg)
 	Debug = true
 
-	mcfg := &MultilineConfig{Expression: ptrFromString("^START")}
+	mcfg := &MultilineConfig{Expression: ptrFromString("^START"), MaxWaitTime: ptrFromString("3s")}
 	err := validateMultilineConfig(mcfg)
 	require.NoError(t, err)
 
@@ -31,17 +34,74 @@ func Test_multilineStage_Process(t *testing.T) {
 
 	out := processEntries(stage, simpleEntry("START line 1"), simpleEntry("not a start line"), simpleEntry("START line 2"), simpleEntry("START line 3"))
 
+	require.Len(t, out, 3)
 	require.Equal(t, "START line 1\nnot a start line", out[0].Line)
 	require.Equal(t, "START line 2", out[1].Line)
 	require.Equal(t, "START line 3", out[2].Line)
 }
+func Test_multilineStage_MaxWaitTime(t *testing.T) {
+	// Enable debug logging
+	cfg := &ww.Config{}
+	require.Nil(t, cfg.LogLevel.Set("debug"))
+	util.InitLogger(cfg)
+	Debug = true
+
+	maxWait := time.Duration(2 * time.Second)
+	mcfg := &MultilineConfig{Expression: ptrFromString("^START"), MaxWaitTime: ptrFromString(maxWait.String())}
+	err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{
+		cfg:    mcfg,
+		logger: util.Logger,
+		buffer: new(bytes.Buffer),
+	}
+
+	in := make(chan Entry, 2)
+	out := stage.Run(in)
+
+	// Accumulate result
+	mu := new(sync.Mutex)
+	var res []Entry
+	go func() {
+		for e := range out {
+			mu.Lock()
+			t.Logf("appending %s", e.Line)
+			res = append(res, e)
+			mu.Unlock()
+		}
+		return
+	}()
+
+	// Write input with a delay
+	go func() {
+		in <- simpleEntry("START line")
+
+		// Trigger flush due to max wait timeout
+		time.Sleep(2 * maxWait)
+
+		in <- simpleEntry("not a start line hitting timeout")
+
+		// Signal pipeline we are done.
+		close(in)
+		return
+	}()
+
+	require.Eventually(t, func() bool {mu.Lock(); defer mu.Unlock(); return len(res) == 2;}, time.Duration(3 * maxWait), time.Second)
+	require.Equal(t, "START line", res[0].Line)
+	require.Equal(t, "not a start line hitting timeout", res[1].Line)
+}
 
 func simpleEntry(line string) Entry {
 	return Entry{
-				Labels:    model.LabelSet{},
-				Line:      ptrFromString(line),
 				Extracted: map[string]interface{}{},
-				Timestamp: ptrFromTime(time.Now()),
+				Entry: api.Entry{
+					Labels:    model.LabelSet{},
+					Entry: logproto.Entry{
+						Timestamp: time.Now(),
+						Line: line,
+					},
+				},
 			}
 
 }

--- a/pkg/logentry/stages/output.go
+++ b/pkg/logentry/stages/output.go
@@ -34,7 +34,7 @@ func validateOutputConfig(cfg *OutputConfig) error {
 }
 
 // newOutputStage creates a new outputStage
-func newOutputStage(logger log.Logger, config interface{}) (*outputStage, error) {
+func newOutputStage(logger log.Logger, config interface{}) (Stage, error) {
 	cfg := &OutputConfig{}
 	err := mapstructure.Decode(config, cfg)
 	if err != nil {
@@ -44,10 +44,10 @@ func newOutputStage(logger log.Logger, config interface{}) (*outputStage, error)
 	if err != nil {
 		return nil, err
 	}
-	return &outputStage{
+	return toStage(&outputStage{
 		cfgs:   cfg,
 		logger: logger,
-	}, nil
+	}), nil
 }
 
 // outputStage will mutate the incoming entry and set it from extracted data

--- a/pkg/logentry/stages/regex.go
+++ b/pkg/logentry/stages/regex.go
@@ -65,11 +65,11 @@ func newRegexStage(logger log.Logger, config interface{}) (Stage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &regexStage{
+	return toStage(&regexStage{
 		cfg:        cfg,
 		expression: expression,
 		logger:     log.With(logger, "component", "stage", "type", "regex"),
-	}, nil
+	}), nil
 }
 
 // parseRegexConfig processes an incoming configuration into a RegexConfig

--- a/pkg/logentry/stages/replace.go
+++ b/pkg/logentry/stages/replace.go
@@ -66,11 +66,11 @@ func newReplaceStage(logger log.Logger, config interface{}) (Stage, error) {
 		return nil, err
 	}
 
-	return &replaceStage{
+	return toStage(&replaceStage{
 		cfg:        cfg,
 		expression: expression,
 		logger:     log.With(logger, "component", "stage", "type", "replace"),
-	}, nil
+	}), nil
 }
 
 // parseReplaceConfig processes an incoming configuration into a ReplaceConfig

--- a/pkg/logentry/stages/replace_test.go
+++ b/pkg/logentry/stages/replace_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 )
 
 var testReplaceYamlSingleStageWithoutSource = `
-pipeline_stages: 
-- replace: 
+pipeline_stages:
+- replace:
     expression: "11.11.11.11 - (\\S+) .*"
     replace: "dummy"
 `
@@ -32,19 +31,19 @@ pipeline_stages:
 `
 
 var testReplaceYamlWithNamedCaputedGroupWithTemplate = `
---- 
-pipeline_stages: 
-  - 
-    replace: 
+---
+pipeline_stages:
+  -
+    replace:
       expression: "^(?P<ip>\\S+) (?P<identd>\\S+) (?P<user>\\S+) \\[(?P<timestamp>[\\w:/]+\\s[+\\-]\\d{4})\\] \"(?P<action>\\S+)\\s?(?P<path>\\S+)?\\s?(?P<protocol>\\S+)?\" (?P<status>\\d{3}|-) (\\d+|-)\\s?\"?(?P<referer>[^\"]*)\"?\\s?\"?(?P<useragent>[^\"]*)?\"?$"
       replace: '{{ if eq .Value "200" }}{{ Replace .Value "200" "HttpStatusOk" -1 }}{{ else }}{{ .Value | ToUpper }}{{ end }}'
 `
 
 var testReplaceYamlWithTemplate = `
---- 
-pipeline_stages: 
-  - 
-    replace: 
+---
+pipeline_stages:
+  -
+    replace:
       expression: "^(\\S+) (\\S+) (\\S+) \\[([\\w:/]+\\s[+\\-]\\d{4})\\] \"(\\S+)\\s?(\\S+)?\\s?(\\S+)?\" (\\d{3}|-) (\\d+|-)\\s?\"?([^\"]*)\"?\\s?\"?([^\"]*)?\"?$"
       replace: '{{ if eq .Value "200" }}{{ Replace .Value "200" "HttpStatusOk" -1 }}{{ else }}{{ .Value | ToUpper }}{{ end }}'
 `
@@ -126,14 +125,9 @@ func TestPipeline_Replace(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			lbls := model.LabelSet{}
-			ts := time.Now()
-			entry := testData.entry
-			extracted := map[string]interface{}{}
-			pl.Process(lbls, extracted, &ts, &entry)
-			assert.Equal(t, testData.expectedEntry, entry)
-			assert.Equal(t, testData.extracted, extracted)
+			out := processEntries(pl, newEntry(nil, nil, testData.entry, time.Now()))[0]
+			assert.Equal(t, testData.expectedEntry, out.Line)
+			assert.Equal(t, testData.extracted, out.Extracted)
 		})
 	}
 }

--- a/pkg/logentry/stages/stage.go
+++ b/pkg/logentry/stages/stage.go
@@ -27,6 +27,7 @@ const (
 	StageTypePipeline  = "pipeline"
 	StageTypeTenant    = "tenant"
 	StageTypeDrop      = "drop"
+	StageTypeMultiline = "multiline"
 )
 
 // Processor takes an existing set of labels, timestamp and log entry and returns either a possibly mutated
@@ -136,6 +137,11 @@ func New(logger log.Logger, jobName *string, stageType string,
 		}
 	case StageTypeDrop:
 		s, err = newDropStage(logger, cfg, registerer)
+		if err != nil {
+			return nil, err
+		}
+	case StageTypeMultiline:
+		s, err = newMultilineStage(logger, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/logentry/stages/template.go
+++ b/pkg/logentry/stages/template.go
@@ -74,7 +74,7 @@ func validateTemplateConfig(cfg *TemplateConfig) (*template.Template, error) {
 }
 
 // newTemplateStage creates a new templateStage
-func newTemplateStage(logger log.Logger, config interface{}) (*templateStage, error) {
+func newTemplateStage(logger log.Logger, config interface{}) (Stage, error) {
 	cfg := &TemplateConfig{}
 	err := mapstructure.Decode(config, cfg)
 	if err != nil {
@@ -85,11 +85,11 @@ func newTemplateStage(logger log.Logger, config interface{}) (*templateStage, er
 		return nil, err
 	}
 
-	return &templateStage{
+	return toStage(&templateStage{
 		cfgs:     cfg,
 		logger:   logger,
 		template: t,
-	}, nil
+	}), nil
 }
 
 // templateStage will mutate the incoming entry and set it from extracted data

--- a/pkg/logentry/stages/tenant.go
+++ b/pkg/logentry/stages/tenant.go
@@ -42,7 +42,7 @@ func validateTenantConfig(c TenantConfig) error {
 }
 
 // newTenantStage creates a new tenant stage to override the tenant ID from extracted data
-func newTenantStage(logger log.Logger, configs interface{}) (*tenantStage, error) {
+func newTenantStage(logger log.Logger, configs interface{}) (Stage, error) {
 	cfg := TenantConfig{}
 	err := mapstructure.Decode(configs, &cfg)
 	if err != nil {
@@ -54,10 +54,10 @@ func newTenantStage(logger log.Logger, configs interface{}) (*tenantStage, error
 		return nil, err
 	}
 
-	return &tenantStage{
+	return toStage(&tenantStage{
 		cfg:    cfg,
 		logger: logger,
-	}, nil
+	}), nil
 }
 
 // Process implements Stage

--- a/pkg/logentry/stages/tenant_test.go
+++ b/pkg/logentry/stages/tenant_test.go
@@ -43,12 +43,9 @@ func TestPipelineWithMissingKey_Tenant(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lbls := model.LabelSet{}
 	Debug = true
-	ts := time.Now()
-	entry := testTenantLogLineWithMissingKey
-	extracted := map[string]interface{}{}
-	pl.Process(lbls, extracted, &ts, &entry)
+
+	_ = processEntries(pl, newEntry(nil, nil, testTenantLogLineWithMissingKey, time.Now()))
 	expectedLog := "level=debug msg=\"failed to convert value to string\" err=\"Can't convert <nil> to string\" type=null"
 	if !(strings.Contains(buf.String(), expectedLog)) {
 		t.Errorf("\nexpected: %s\n+actual: %s", expectedLog, buf.String())
@@ -178,17 +175,13 @@ func TestTenantStage_Process(t *testing.T) {
 
 			// Process and dummy line and ensure nothing has changed except
 			// the tenant reserved label
-			timestamp := time.Unix(1, 1)
-			entry := "hello world"
-			labels := testData.inputLabels.Clone()
-			extracted := testData.inputExtracted
 
-			stage.Process(labels, extracted, &timestamp, &entry)
+			out := processEntries(stage, newEntry(testData.inputExtracted, testData.inputLabels.Clone(), "hello world", time.Unix(1, 1)))[0]
 
-			assert.Equal(t, time.Unix(1, 1), timestamp)
-			assert.Equal(t, "hello world", entry)
+			assert.Equal(t, time.Unix(1, 1), out.Timestamp)
+			assert.Equal(t, "hello world", out.Line)
 
-			actualTenant, ok := labels[client.ReservedLabelTenantID]
+			actualTenant, ok := out.Labels[client.ReservedLabelTenantID]
 			if testData.expectedTenant == nil {
 				assert.False(t, ok)
 			} else {

--- a/pkg/logentry/stages/timestamp.go
+++ b/pkg/logentry/stages/timestamp.go
@@ -103,7 +103,7 @@ func validateTimestampConfig(cfg *TimestampConfig) (parser, error) {
 }
 
 // newTimestampStage creates a new timestamp extraction pipeline stage.
-func newTimestampStage(logger log.Logger, config interface{}) (*timestampStage, error) {
+func newTimestampStage(logger log.Logger, config interface{}) (Stage, error) {
 	cfg := &TimestampConfig{}
 	err := mapstructure.Decode(config, cfg)
 	if err != nil {
@@ -122,12 +122,12 @@ func newTimestampStage(logger log.Logger, config interface{}) (*timestampStage, 
 		}
 	}
 
-	return &timestampStage{
+	return toStage(&timestampStage{
 		cfg:                 cfg,
 		logger:              logger,
 		parser:              parser,
 		lastKnownTimestamps: lastKnownTimestamps,
-	}, nil
+	}), nil
 }
 
 // timestampStage will set the timestamp using extracted data

--- a/pkg/logentry/stages/util_test.go
+++ b/pkg/logentry/stages/util_test.go
@@ -7,7 +7,29 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/api"
 )
+
+func newEntry(ex map[string]interface{}, lbs model.LabelSet, line string, ts time.Time) Entry {
+	if ex == nil {
+		ex = map[string]interface{}{}
+	}
+	if lbs == nil {
+		lbs = model.LabelSet{}
+	}
+	return Entry{
+		Extracted: ex,
+		Entry: api.Entry{
+			Labels: lbs,
+			Entry: logproto.Entry{
+				Timestamp: ts,
+				Line:      line,
+			},
+		},
+	}
+}
 
 // nolint
 func mustParseTime(layout, value string) time.Time {

--- a/pkg/promtail/client/batch.go
+++ b/pkg/promtail/client/batch.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/snappy"
 
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/api"
 )
 
 // batch holds pending log streams waiting to be sent to Loki, and it's used
@@ -19,7 +20,7 @@ type batch struct {
 	createdAt time.Time
 }
 
-func newBatch(entries ...entry) *batch {
+func newBatch(entries ...api.Entry) *batch {
 	b := &batch{
 		streams:   map[string]*logproto.Stream{},
 		bytes:     0,
@@ -35,11 +36,11 @@ func newBatch(entries ...entry) *batch {
 }
 
 // add an entry to the batch
-func (b *batch) add(entry entry) {
+func (b *batch) add(entry api.Entry) {
 	b.bytes += len(entry.Line)
 
 	// Append the entry to an already existing stream (if any)
-	labels := entry.labels.String()
+	labels := entry.Labels.String()
 	if stream, ok := b.streams[labels]; ok {
 		stream.Entries = append(stream.Entries, entry.Entry)
 		return
@@ -59,7 +60,7 @@ func (b *batch) sizeBytes() int {
 
 // sizeBytesAfter returns the size of the batch after the input entry
 // will be added to the batch itself
-func (b *batch) sizeBytesAfter(entry entry) int {
+func (b *batch) sizeBytesAfter(entry api.Entry) int {
 	return b.bytes + len(entry.Line)
 }
 

--- a/pkg/promtail/client/fake/client.go
+++ b/pkg/promtail/client/fake/client.go
@@ -1,30 +1,58 @@
 package fake
 
 import (
-	"time"
-
-	"github.com/prometheus/common/model"
+	"sync"
 
 	"github.com/grafana/loki/pkg/promtail/api"
 )
 
 // Client is a fake client used for testing.
 type Client struct {
-	OnHandleEntry api.EntryHandlerFunc
-	OnStop        func()
+	entries  chan api.Entry
+	received []api.Entry
+	once     sync.Once
+	mtx      sync.Mutex
+	wg       sync.WaitGroup
+	OnStop   func()
+}
+
+func New(stop func()) *Client {
+	c := &Client{
+		OnStop:  stop,
+		entries: make(chan api.Entry),
+	}
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		for e := range c.entries {
+			c.mtx.Lock()
+			c.received = append(c.received, e)
+			c.mtx.Unlock()
+		}
+	}()
+	return c
 }
 
 // Stop implements client.Client
 func (c *Client) Stop() {
+	c.once.Do(func() { close(c.entries) })
+	c.wg.Wait()
 	c.OnStop()
+}
+
+func (c *Client) Chan() chan<- api.Entry {
+	return c.entries
+}
+
+func (c *Client) Received() []api.Entry {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	cpy := make([]api.Entry, len(c.received))
+	copy(cpy, c.received)
+	return cpy
 }
 
 // StopNow implements client.Client
 func (c *Client) StopNow() {
-	c.OnStop()
-}
-
-// Handle implements client.Client
-func (c *Client) Handle(labels model.LabelSet, time time.Time, entry string) error {
-	return c.OnHandleEntry.Handle(labels, time, entry)
+	c.Stop()
 }

--- a/pkg/promtail/client/logger.go
+++ b/pkg/promtail/client/logger.go
@@ -6,13 +6,12 @@ import (
 	"runtime"
 	"sync"
 	"text/tabwriter"
-	"time"
 
 	"github.com/fatih/color"
 	"github.com/go-kit/kit/log"
-	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
 
+	"github.com/grafana/loki/pkg/promtail/api"
 	lokiflag "github.com/grafana/loki/pkg/util/flagext"
 )
 
@@ -31,6 +30,9 @@ func init() {
 type logger struct {
 	*tabwriter.Writer
 	sync.Mutex
+	entries chan api.Entry
+
+	once sync.Once
 }
 
 // NewLogger creates a new client logger that logs entries instead of sending them.
@@ -51,24 +53,33 @@ func NewLogger(log log.Logger, externalLabels lokiflag.LabelSet, cfgs ...Config)
 		fmt.Println("----------------------")
 		fmt.Println(string(yaml))
 	}
-	return &logger{
-		Writer: tabwriter.NewWriter(os.Stdout, 0, 8, 0, '\t', 0),
-	}, nil
+	entries := make(chan api.Entry)
+	l := &logger{
+		Writer:  tabwriter.NewWriter(os.Stdout, 0, 8, 0, '\t', 0),
+		entries: entries,
+	}
+	go l.run()
+	return l, nil
 }
 
-func (*logger) Stop() {}
-
-func (*logger) StopNow() {}
-
-func (l *logger) Handle(labels model.LabelSet, time time.Time, entry string) error {
-	l.Lock()
-	defer l.Unlock()
-	fmt.Fprint(l.Writer, blue.Sprint(time.Format("2006-01-02T15:04:05")))
-	fmt.Fprint(l.Writer, "\t")
-	fmt.Fprint(l.Writer, yellow.Sprint(labels.String()))
-	fmt.Fprint(l.Writer, "\t")
-	fmt.Fprint(l.Writer, entry)
-	fmt.Fprint(l.Writer, "\n")
-	l.Flush()
-	return nil
+func (l *logger) Stop() {
+	l.once.Do(func() { close(l.entries) })
 }
+
+func (l *logger) Chan() chan<- api.Entry {
+	return l.entries
+}
+
+func (l *logger) run() {
+	for e := range l.entries {
+		fmt.Fprint(l.Writer, blue.Sprint(e.Timestamp.Format("2006-01-02T15:04:05")))
+		fmt.Fprint(l.Writer, "\t")
+		fmt.Fprint(l.Writer, yellow.Sprint(e.Labels.String()))
+		fmt.Fprint(l.Writer, "\t")
+		fmt.Fprint(l.Writer, e.Line)
+		fmt.Fprint(l.Writer, "\n")
+		l.Flush()
+	}
+
+}
+func (l *logger) StopNow() { l.Stop() }

--- a/pkg/promtail/client/logger_test.go
+++ b/pkg/promtail/client/logger_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/api"
 	"github.com/grafana/loki/pkg/util/flagext"
 )
 
@@ -19,6 +21,7 @@ func TestNewLogger(t *testing.T) {
 
 	l, err := NewLogger(util.Logger, flagext.LabelSet{}, []Config{{URL: cortexflag.URLValue{URL: &url.URL{Host: "string"}}}}...)
 	require.NoError(t, err)
-	err = l.Handle(model.LabelSet{"foo": "bar"}, time.Now(), "entry")
-	require.NoError(t, err)
+	l.Chan() <- api.Entry{Labels: model.LabelSet{"foo": "bar"}, Entry: logproto.Entry{Timestamp: time.Now(), Line: "entry"}}
+	l.Stop()
+
 }

--- a/pkg/promtail/client/multi.go
+++ b/pkg/promtail/client/multi.go
@@ -2,17 +2,22 @@ package client
 
 import (
 	"errors"
-	"time"
+	"sync"
 
 	"github.com/go-kit/kit/log"
-	"github.com/prometheus/common/model"
 
-	"github.com/grafana/loki/pkg/util"
+	"github.com/grafana/loki/pkg/promtail/api"
 	"github.com/grafana/loki/pkg/util/flagext"
 )
 
 // MultiClient is client pushing to one or more loki instances.
-type MultiClient []Client
+type MultiClient struct {
+	clients []Client
+	entries chan api.Entry
+	wg      sync.WaitGroup
+
+	once sync.Once
+}
 
 // NewMulti creates a new client
 func NewMulti(logger log.Logger, externalLabels flagext.LabelSet, cfgs ...Config) (Client, error) {
@@ -35,30 +40,42 @@ func NewMulti(logger log.Logger, externalLabels flagext.LabelSet, cfgs ...Config
 		}
 		clients = append(clients, client)
 	}
-	return MultiClient(clients), nil
+	multi := &MultiClient{
+		clients: clients,
+		entries: make(chan api.Entry),
+	}
+	multi.start()
+	return multi, nil
 }
 
-// Handle Implements api.EntryHandler
-func (m MultiClient) Handle(labels model.LabelSet, time time.Time, entry string) error {
-	var result util.MultiError
-	for _, client := range m {
-		if err := client.Handle(labels, time, entry); err != nil {
-			result.Add(err)
+func (m *MultiClient) start() {
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		for e := range m.entries {
+			for _, c := range m.clients {
+				c.Chan() <- e
+			}
 		}
-	}
-	return result.Err()
+	}()
+}
+
+func (m *MultiClient) Chan() chan<- api.Entry {
+	return m.entries
 }
 
 // Stop implements Client
-func (m MultiClient) Stop() {
-	for _, c := range m {
+func (m *MultiClient) Stop() {
+	m.once.Do(func() { close(m.entries) })
+	m.wg.Wait()
+	for _, c := range m.clients {
 		c.Stop()
 	}
 }
 
 // StopNow implements Client
-func (m MultiClient) StopNow() {
-	for _, c := range m {
+func (m *MultiClient) StopNow() {
+	for _, c := range m.clients {
 		c.StopNow()
 	}
 }

--- a/pkg/promtail/client/multi_test.go
+++ b/pkg/promtail/client/multi_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"errors"
 	"net/url"
 	"reflect"
 	"testing"
@@ -11,6 +10,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/promtail/api"
 	lokiflag "github.com/grafana/loki/pkg/util/flagext"
 
@@ -41,11 +41,11 @@ func TestNewMulti(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected err: nil got:%v", err)
 	}
-	multi := clients.(MultiClient)
-	if len(multi) != 2 {
-		t.Fatalf("expected client: 2 got:%d", len(multi))
+	multi := clients.(*MultiClient)
+	if len(multi.clients) != 2 {
+		t.Fatalf("expected client: 2 got:%d", len(multi.clients))
 	}
-	actualCfg1 := clients.(MultiClient)[0].(*client).cfg
+	actualCfg1 := clients.(*MultiClient).clients[0].(*client).cfg
 	// Yaml should overried the command line so 'order: yaml' should be expected
 	expectedCfg1 := Config{
 		BatchSize:      20,
@@ -58,7 +58,7 @@ func TestNewMulti(t *testing.T) {
 		t.Fatalf("expected cfg: %v got:%v", expectedCfg1, actualCfg1)
 	}
 
-	actualCfg2 := clients.(MultiClient)[1].(*client).cfg
+	actualCfg2 := clients.(*MultiClient).clients[1].(*client).cfg
 	// No overlapping label keys so both should be in the output
 	expectedCfg2 := Config{
 		BatchSize: 10,
@@ -83,10 +83,13 @@ func TestMultiClient_Stop(t *testing.T) {
 	stopping := func() {
 		stopped++
 	}
-	fc := &fake.Client{OnStop: stopping}
+	fc := fake.New(stopping)
 	clients := []Client{fc, fc, fc, fc}
-	m := MultiClient(clients)
-
+	m := &MultiClient{
+		clients: clients,
+		entries: make(chan api.Entry),
+	}
+	m.start()
 	m.Stop()
 
 	if stopped != len(clients) {
@@ -96,39 +99,20 @@ func TestMultiClient_Stop(t *testing.T) {
 
 func TestMultiClient_Handle(t *testing.T) {
 
-	var called int
+	f := fake.New(func() {})
+	clients := []Client{f, f, f, f, f, f}
+	m := &MultiClient{
+		clients: clients,
+		entries: make(chan api.Entry),
+	}
+	m.start()
 
-	errorFn := api.EntryHandlerFunc(func(labels model.LabelSet, time time.Time, entry string) error { called++; return errors.New("") })
-	okFn := api.EntryHandlerFunc(func(labels model.LabelSet, time time.Time, entry string) error { called++; return nil })
+	m.Chan() <- api.Entry{Labels: model.LabelSet{"foo": "bar"}, Entry: logproto.Entry{Line: "foo"}}
 
-	errfc := &fake.Client{OnHandleEntry: errorFn}
-	okfc := &fake.Client{OnHandleEntry: okFn}
-	t.Run("some error", func(t *testing.T) {
-		clients := []Client{okfc, errfc, okfc, errfc, errfc, okfc}
-		m := MultiClient(clients)
+	m.Stop()
 
-		if err := m.Handle(nil, time.Now(), ""); err == nil {
-			t.Fatal("expected err got nil")
-		}
-
-		if called != len(clients) {
-			t.Fatal("missing handle call")
-		}
-
-	})
-	t.Run("no error", func(t *testing.T) {
-		called = 0
-		clients := []Client{okfc, okfc, okfc, okfc, okfc, okfc}
-		m := MultiClient(clients)
-
-		if err := m.Handle(nil, time.Now(), ""); err != nil {
-			t.Fatal("expected err to be nil")
-		}
-
-		if called != len(clients) {
-			t.Fatal("missing handle call")
-		}
-
-	})
+	if len(f.Received()) != len(clients) {
+		t.Fatal("missing handle call")
+	}
 
 }

--- a/pkg/promtail/promtail.go
+++ b/pkg/promtail/promtail.go
@@ -114,5 +114,6 @@ func (p *Promtail) Shutdown() {
 	if p.targetManagers != nil {
 		p.targetManagers.Stop()
 	}
+	// todo work out the stop.
 	p.client.Stop()
 }

--- a/pkg/promtail/promtail_test.go
+++ b/pkg/promtail/promtail_test.go
@@ -656,5 +656,5 @@ func Test_DryRun(t *testing.T) {
 		},
 	}, false)
 	require.NoError(t, err)
-	require.IsType(t, client.MultiClient{}, p.client)
+	require.IsType(t, &client.MultiClient{}, p.client)
 }

--- a/pkg/promtail/targets/file/filetarget.go
+++ b/pkg/promtail/targets/file/filetarget.go
@@ -134,6 +134,7 @@ func (t *FileTarget) Ready() bool {
 func (t *FileTarget) Stop() {
 	close(t.quit)
 	<-t.done
+	t.handler.Stop()
 }
 
 // Type implements a Target

--- a/pkg/promtail/targets/file/filetargetmanager.go
+++ b/pkg/promtail/targets/file/filetargetmanager.go
@@ -323,6 +323,7 @@ func (s *targetSyncer) stop() {
 		target.Stop()
 		delete(s.targets, key)
 	}
+	s.entryHandler.Stop()
 }
 
 func hostname() (string, error) {

--- a/pkg/promtail/targets/file/tailer.go
+++ b/pkg/promtail/targets/file/tailer.go
@@ -135,7 +135,7 @@ func (t *tailer) readLines() {
 	for {
 		line, ok := <-t.tail.Lines
 		if !ok {
-			level.Info(t.logger).Log("msg", "tail routine: tail channel closed, stopping tailer", "path", t.path)
+			level.Info(t.logger).Log("msg", "tail routine: tail channel closed, stopping tailer", "path", t.path, "reason", t.tail.Tomb.Err())
 			return
 		}
 

--- a/pkg/promtail/targets/journal/journaltarget.go
+++ b/pkg/promtail/targets/journal/journaltarget.go
@@ -9,24 +9,20 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-systemd/sdjournal"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
 
-	"github.com/go-kit/kit/log/level"
-
-	"github.com/grafana/loki/pkg/promtail/positions"
-	"github.com/grafana/loki/pkg/promtail/targets/target"
-
-	"github.com/go-kit/kit/log"
-
-	"github.com/grafana/loki/pkg/promtail/scrapeconfig"
-
-	"github.com/coreos/go-systemd/sdjournal"
-	"github.com/pkg/errors"
-	"github.com/prometheus/common/model"
-
+	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/promtail/api"
+	"github.com/grafana/loki/pkg/promtail/positions"
+	"github.com/grafana/loki/pkg/promtail/scrapeconfig"
+	"github.com/grafana/loki/pkg/promtail/targets/target"
 )
 
 const (
@@ -294,8 +290,14 @@ func (t *JournalTarget) formatter(entry *sdjournal.JournalEntry) (string, error)
 	}
 
 	t.positions.PutString(t.positionPath, entry.Cursor)
-	err := t.handler.Handle(labels, ts, msg)
-	return journalEmptyStr, err
+	t.handler.Chan() <- api.Entry{
+		Labels: labels,
+		Entry: logproto.Entry{
+			Line:      msg,
+			Timestamp: ts,
+		},
+	}
+	return journalEmptyStr, nil
 }
 
 // Type returns JournalTargetType.
@@ -332,7 +334,9 @@ func (t *JournalTarget) Details() interface{} {
 // Stop shuts down the JournalTarget.
 func (t *JournalTarget) Stop() error {
 	t.until <- time.Now()
-	return t.r.Close()
+	err := t.r.Close()
+	t.handler.Stop()
+	return err
 }
 
 func makeJournalFields(fields map[string]string) map[string]string {

--- a/pkg/promtail/targets/journal/journaltarget_test.go
+++ b/pkg/promtail/targets/journal/journaltarget_test.go
@@ -3,27 +3,22 @@
 package journal
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/coreos/go-systemd/sdjournal"
-
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/prometheus/pkg/relabel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
-	"github.com/prometheus/prometheus/pkg/relabel"
-
-	"github.com/stretchr/testify/assert"
-
+	"github.com/grafana/loki/pkg/promtail/client/fake"
+	"github.com/grafana/loki/pkg/promtail/positions"
 	"github.com/grafana/loki/pkg/promtail/scrapeconfig"
 	"github.com/grafana/loki/pkg/promtail/targets/testutils"
-
-	"github.com/go-kit/kit/log"
-	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/loki/pkg/promtail/positions"
 )
 
 type mockJournalReader struct {
@@ -86,10 +81,7 @@ func TestJournalTarget(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client := &testutils.TestClient{
-		Log:      logger,
-		Messages: make([]*testutils.Entry, 0),
-	}
+	client := fake.New(func() {})
 
 	relabelCfg := `
 - source_labels: ['__journal_code_file']
@@ -115,9 +107,9 @@ func TestJournalTarget(t *testing.T) {
 		})
 		assert.NoError(t, err)
 	}
-	fmt.Println(client.Messages)
-	assert.Len(t, client.Messages, 10)
 	require.NoError(t, jt.Stop())
+	client.Stop()
+	assert.Len(t, client.Received(), 10)
 }
 
 func TestJournalTarget_JSON(t *testing.T) {
@@ -139,10 +131,7 @@ func TestJournalTarget_JSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client := &testutils.TestClient{
-		Log:      logger,
-		Messages: make([]*testutils.Entry, 0),
-	}
+	client := fake.New(func() {})
 
 	relabelCfg := `
 - source_labels: ['__journal_code_file']
@@ -171,14 +160,16 @@ func TestJournalTarget_JSON(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		expectMsg := `{"CODE_FILE":"journaltarget_test.go","MESSAGE":"ping","OTHER_FIELD":"foobar"}`
+	}
+	expectMsg := `{"CODE_FILE":"journaltarget_test.go","MESSAGE":"ping","OTHER_FIELD":"foobar"}`
+	require.NoError(t, jt.Stop())
+	client.Stop()
 
-		require.Greater(t, len(client.Messages), 0)
-		require.Equal(t, expectMsg, client.Messages[len(client.Messages)-1].Log)
+	assert.Len(t, client.Received(), 10)
+	for i := 0; i < 10; i++ {
+		require.Equal(t, expectMsg, client.Received()[i].Line)
 	}
 
-	assert.Len(t, client.Messages, 10)
-	require.NoError(t, jt.Stop())
 }
 
 func TestJournalTarget_Since(t *testing.T) {
@@ -200,10 +191,7 @@ func TestJournalTarget_Since(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client := &testutils.TestClient{
-		Log:      logger,
-		Messages: make([]*testutils.Entry, 0),
-	}
+	client := fake.New(func() {})
 
 	cfg := scrapeconfig.JournalTargetConfig{
 		MaxAge: "4h",
@@ -215,6 +203,7 @@ func TestJournalTarget_Since(t *testing.T) {
 
 	r := jt.r.(*mockJournalReader)
 	require.Equal(t, r.config.Since, -1*time.Hour*4)
+	client.Stop()
 }
 
 func TestJournalTarget_Cursor_TooOld(t *testing.T) {
@@ -237,10 +226,7 @@ func TestJournalTarget_Cursor_TooOld(t *testing.T) {
 	}
 	ps.PutString("journal-test", "foobar")
 
-	client := &testutils.TestClient{
-		Log:      logger,
-		Messages: make([]*testutils.Entry, 0),
-	}
+	client := fake.New(func() {})
 
 	cfg := scrapeconfig.JournalTargetConfig{}
 
@@ -257,6 +243,7 @@ func TestJournalTarget_Cursor_TooOld(t *testing.T) {
 
 	r := jt.r.(*mockJournalReader)
 	require.Equal(t, r.config.Since, -1*time.Hour*7)
+	client.Stop()
 }
 
 func TestJournalTarget_Cursor_NotTooOld(t *testing.T) {
@@ -279,10 +266,7 @@ func TestJournalTarget_Cursor_NotTooOld(t *testing.T) {
 	}
 	ps.PutString("journal-test", "foobar")
 
-	client := &testutils.TestClient{
-		Log:      logger,
-		Messages: make([]*testutils.Entry, 0),
-	}
+	client := fake.New(func() {})
 
 	cfg := scrapeconfig.JournalTargetConfig{}
 
@@ -300,6 +284,7 @@ func TestJournalTarget_Cursor_NotTooOld(t *testing.T) {
 	r := jt.r.(*mockJournalReader)
 	require.Equal(t, r.config.Since, time.Duration(0))
 	require.Equal(t, r.config.Cursor, "foobar")
+	client.Stop()
 }
 
 func Test_MakeJournalFields(t *testing.T) {

--- a/pkg/promtail/targets/lokipush/pushtarget_test.go
+++ b/pkg/promtail/targets/lokipush/pushtarget_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/server"
 
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/api"
 	"github.com/grafana/loki/pkg/promtail/client"
+	"github.com/grafana/loki/pkg/promtail/client/fake"
 	"github.com/grafana/loki/pkg/promtail/scrapeconfig"
-	"github.com/grafana/loki/pkg/promtail/targets/testutils"
 )
 
 func TestPushTarget(t *testing.T) {
@@ -25,10 +27,8 @@ func TestPushTarget(t *testing.T) {
 	logger := log.NewLogfmtLogger(w)
 
 	//Create PushTarget
-	eh := &testutils.TestClient{
-		Log:      logger,
-		Messages: make([]*testutils.Entry, 0),
-	}
+	eh := fake.New(func() {})
+	defer eh.Stop()
 
 	// Get a randomly available port by open and closing a TCP socket
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
@@ -79,6 +79,7 @@ func TestPushTarget(t *testing.T) {
 	}
 	pc, err := client.New(ccfg, logger)
 	require.NoError(t, err)
+	defer pc.Stop()
 
 	// Send some logs
 	labels := model.LabelSet{
@@ -86,19 +87,24 @@ func TestPushTarget(t *testing.T) {
 		"__anotherdroplabel": "dropme",
 	}
 	for i := 0; i < 100; i++ {
-		err := pc.Handle(labels, time.Unix(int64(i), 0), "line"+strconv.Itoa(i))
-		require.NoError(t, err)
+		pc.Chan() <- api.Entry{
+			Labels: labels,
+			Entry: logproto.Entry{
+				Timestamp: time.Unix(int64(i), 0),
+				Line:      "line" + strconv.Itoa(i),
+			},
+		}
 	}
 
 	// Wait for them to appear in the test handler
 	countdown := 10000
-	for len(eh.Messages) != 100 && countdown > 0 {
+	for len(eh.Received()) != 100 && countdown > 0 {
 		time.Sleep(1 * time.Millisecond)
 		countdown--
 	}
 
 	// Make sure we didn't timeout
-	require.Equal(t, 100, len(eh.Messages))
+	require.Equal(t, 100, len(eh.Received()))
 
 	// Verify labels
 	expectedLabels := model.LabelSet{
@@ -106,10 +112,10 @@ func TestPushTarget(t *testing.T) {
 		"stream":     "stream1",
 	}
 	// Spot check the first value in the result to make sure relabel rules were applied properly
-	require.Equal(t, expectedLabels, eh.Messages[0].Labels)
+	require.Equal(t, expectedLabels, eh.Received()[0].Labels)
 
 	// With keep timestamp enabled, verify timestamp
-	require.Equal(t, time.Unix(99, 0).Unix(), eh.Messages[99].Time.Unix())
+	require.Equal(t, time.Unix(99, 0).Unix(), eh.Received()[99].Timestamp.Unix())
 
 	_ = pt.Stop()
 

--- a/pkg/promtail/targets/testutils/testutils.go
+++ b/pkg/promtail/targets/testutils/testutils.go
@@ -2,34 +2,8 @@ package testutils
 
 import (
 	"math/rand"
-	"sync"
 	"time"
-
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
-	"github.com/prometheus/common/model"
 )
-
-type Entry struct {
-	Labels model.LabelSet
-	Time   time.Time
-	Log    string
-}
-
-type TestClient struct {
-	Log      log.Logger
-	Messages []*Entry
-	sync.Mutex
-}
-
-func (c *TestClient) Handle(ls model.LabelSet, t time.Time, s string) error {
-	level.Debug(c.Log).Log("msg", "received log", "log", s)
-
-	c.Lock()
-	defer c.Unlock()
-	c.Messages = append(c.Messages, &Entry{ls, t, s})
-	return nil
-}
 
 func InitRandom() {
 	rand.Seed(time.Now().UnixNano())

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -12,16 +12,18 @@
     // flag for tuning things when boltdb-shipper is current or upcoming index type.
     using_boltdb_shipper: true,
 
+    wal_enabled: false,
+
     // flags for running ingesters/queriers as a statefulset instead of deployment type.
-    stateful_ingesters:  false,
-    ingester_pvc_size:   '5Gi',
-    ingester_pvc_class:  'fast',
+    stateful_ingesters: false,
+    ingester_pvc_size: '5Gi',
+    ingester_pvc_class: 'fast',
 
-    stateful_queriers:   false,
-    querier_pvc_size:    '10Gi',
-    querier_pvc_class:   'fast',
+    stateful_queriers: false,
+    querier_pvc_size: '10Gi',
+    querier_pvc_class: 'fast',
 
-    compactor_pvc_size:  '10Gi',
+    compactor_pvc_size: '10Gi',
     compactor_pvc_class: 'fast',
 
 

--- a/production/ksonnet/loki/loki.libsonnet
+++ b/production/ksonnet/loki/loki.libsonnet
@@ -17,5 +17,8 @@
 // Supporting services
 (import 'memcached.libsonnet') +
 
+// WAL support
+(import 'wal.libsonnet') +
+
 // BoltDB Shipper support. This should be the last one to get imported.
 (import 'boltdb_shipper.libsonnet')

--- a/production/ksonnet/loki/wal.libsonnet
+++ b/production/ksonnet/loki/wal.libsonnet
@@ -1,0 +1,47 @@
+{
+  local with(x) = if $._config.wal_enabled then x else {},
+
+  _config+:: {
+    stateful_ingesters: if $._config.wal_enabled then true else super.stateful_ingesters,
+    loki+:with({
+      ingester+:{
+        // disables transfers when running as statefulsets.
+        // pod rolling stragety will always fail transfers
+        // and the WAL supersedes this.
+        max_transfer_retries: 0,
+        wal+: {
+          enabled: true,
+          dir: '/loki/wal',
+          recover: true,
+        },
+      },
+    }),
+  },
+
+  local pvc = $.core.v1.persistentVolumeClaim,
+
+  ingester_wal_pvc:: with(
+    pvc.new('ingester-wal') +
+    pvc.mixin.spec.resources.withRequests({ storage: '150Gi' }) +
+    pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
+    pvc.mixin.spec.withStorageClassName($._config.ingester_pvc_class)
+  ),
+
+  local container = $.core.v1.container,
+  local volumeMount = $.core.v1.volumeMount,
+
+  ingester_container+:: with(
+    $.util.resourcesRequests('1', '7Gi') +
+    $.util.resourcesLimits('2', '14Gi') +
+    container.withVolumeMountsMixin([
+      volumeMount.new('ingester-wal', $._config.loki.ingester.wal.dir),
+    ]),
+  ),
+
+
+  local statefulSet = $.apps.v1.statefulSet,
+  ingester_statefulset+: with(
+    statefulSet.spec.withVolumeClaimTemplatesMixin($.ingester_wal_pvc),
+  ),
+
+}


### PR DESCRIPTION
Summary:
This is a very simple approach based on grafana#1380 to provide multiline
or block log entries in promtail.

A `multiline` stage is added to pipelines. This stages matches a start
line. Once a start line is matched all following lines are appended
to an entry and not passed on to downstream stages. Once a new start
line is matched the former block of multilines is sent.

If now new line arrives withing `max_wait_time` the block is flushed to
the next stage and a new block is started.